### PR TITLE
Add ept prefix to the sort_by shortcode attribute

### DIFF
--- a/src/Integration/Barn2_Table_Plugin.php
+++ b/src/Integration/Barn2_Table_Plugin.php
@@ -138,6 +138,9 @@ class Barn2_Table_Plugin implements Registerable, Service {
 			}
 		}
 
+		$out['sort_by'] = $this->prefix_taxs_and_fields( $out['sort_by'], $post_type );
+		$out['sort_by'] = substr( $out['sort_by'], 0, strrpos( $out['sort_by'], ':' ) );
+
 		return $out;
 	}
 


### PR DESCRIPTION
This allows Barn2 plugins, such as DLP, PTP and WPT, to use the "sort_by" shortcode attribute without the need to add the post type prefix, for custom fields and taxonomies.