### PR TITLE
Fixed issue with integration with table plugins sort_by shortcode attribute

### DIFF
--- a/src/Integration/Barn2_Table_Plugin.php
+++ b/src/Integration/Barn2_Table_Plugin.php
@@ -139,7 +139,9 @@ class Barn2_Table_Plugin implements Registerable, Service {
 		}
 
 		$out['sort_by'] = $this->prefix_taxs_and_fields( $out['sort_by'], $post_type );
-		$out['sort_by'] = substr( $out['sort_by'], 0, strrpos( $out['sort_by'], ':' ) );
+		if ( substr_count( $out['sort_by'], ':' ) > 1 ) {
+			$out['sort_by'] = substr( $out['sort_by'], 0, strrpos( $out['sort_by'], ':' ) );
+		}
 
 		return $out;
 	}


### PR DESCRIPTION
We need to have the new condition:

if ( substr_count( $out['sort_by'], ':' ) > 1 ) {

So that other sort_by fields, besides EPT custom fields, works normally.